### PR TITLE
Move mouse cursor after `Alt+Tab` when using `switch-applications`

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -25,7 +25,7 @@ function init() {
         class CurrentMonitorAppSwitcherPopup extends altTab.AppSwitcherPopup {
             _finish(timestamp) {
                 if (this._currentWindow < 0) {
-                    extension.movePointer();
+                    extension.movePointerMaybe(appIcon.cachedWindows[0]);
                 }
                 super._finish(timestamp);
             }

--- a/extension.js
+++ b/extension.js
@@ -24,12 +24,14 @@ function init() {
     CurrentMonitorAppSwitcherPopup = GObject.registerClass(
         class CurrentMonitorAppSwitcherPopup extends altTab.AppSwitcherPopup {
             _finish(timestamp) {
+                let appIcon = this._items[this._selectedIndex];
                 if (this._currentWindow < 0) {
                     extension.movePointerMaybe(appIcon.cachedWindows[0]);
                 }
                 super._finish(timestamp);
             }
-        });
+        }
+	);
 }
 
 class Extension {

--- a/extension.js
+++ b/extension.js
@@ -20,20 +20,7 @@ const Main = imports.ui.main;
 const altTab = imports.ui.altTab;
 
 let CurrentMonitorAppSwitcherPopup;
-
-function init() {
-    CurrentMonitorAppSwitcherPopup = GObject.registerClass(
-        class CurrentMonitorAppSwitcherPopup extends altTab.AppSwitcherPopup {
-            _finish(timestamp) {
-                let appIcon = this._items[this._selectedIndex];
-                if (this._currentWindow < 0) {
-                    extension.movePointerMaybe(appIcon.cachedWindows[0]);
-                }
-                super._finish(timestamp);
-            }
-        }
-	);
-}
+let extension = null;
 
 class Extension {
   constructor() {
@@ -74,7 +61,19 @@ class Extension {
   }
 }
 
-let extension = null;
+function init() {
+    CurrentMonitorAppSwitcherPopup = GObject.registerClass(
+        class CurrentMonitorAppSwitcherPopup extends altTab.AppSwitcherPopup {
+            _finish(timestamp) {
+                let appIcon = this._items[this._selectedIndex];
+                if (this._currentWindow < 0) {
+                    extension.movePointerMaybe(appIcon.cachedWindows[0]);
+                }
+                super._finish(timestamp);
+            }
+        }
+	);
+}
 
 /* exported enable */
 function enable() {

--- a/extension.js
+++ b/extension.js
@@ -1,5 +1,6 @@
-// Copyright (C) 2021  Taiki Sugawara
+// Copyright (C) 2022  Lucas Emanuel Resck
 // Copyright (C) 2022  vakokako
+// Copyright (C) 2021  Taiki Sugawara
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Hi there,

This should fix https://github.com/buzztaiki/gnome-shell-extension-alt-tab-move-mouse/issues/7, making the extension work with the `switch-applications` shortcut.

Basically, it inherits from `AppSwitcherPopup` in `imports.ui.altTab` and modifies its `_finish` method. This is analogous to the current modification of `Main.activateWindow` for the `switch-windows` shortcut because `Main.activateWindow` is called inside the `_finish` method of the class `WindowSwitcherPopup`.

I would suggest updating the `switch-windows` approach by using `WindowSwitcherPopup` inheritance because it is easier to understand, in my opinion, and it is analogous to the approach in this pull request; take a look at https://github.com/lucasresck/gnome-shell-extension-alt-tab-scroll-workaround/commit/fede46dd2fb6fbd2368ca441754da87130c7e55e as an example. If this PR is approved, I can work on that!

I would like to use this opportunity to also thank you for this extension. Based on yours, I created the [Alt+Tab Scroll Workaround](https://github.com/lucasresck/gnome-shell-extension-alt-tab-scroll-workaround) to approach a very annoying problem involving mouse scroll and `Alt+Tab` on GNOME. Also, thanks for @vakokako (included in the commits) who basically solved this issue but in my extension (https://github.com/lucasresck/gnome-shell-extension-alt-tab-scroll-workaround/issues/2, https://github.com/lucasresck/gnome-shell-extension-alt-tab-scroll-workaround/pull/8).