### PR TITLE
fixed for gnome 45+

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,9 +2,10 @@
   "name": "Alt-Tab Move Mouse",
   "description": "Move mouse pointer onto active window after Alt-Tab. This extension is workaround of some sloppy focus problems",
   "uuid": "alt-tab-move-mouse@buzztaiki.github.com",
-  "version": 2,
+  "version": 3,
   "url": "https://github.com/buzztaiki/gnome-shell-extension-alt-tab-move-mouse",
   "shell-version": [
-    "40", "41", "42"
+    "45",
+    "46"
   ]
 }


### PR DESCRIPTION
I was able to update this extension to work on gnome 46 (gnome introduced breaking changes in 45 so it should work in 45 and above), thanks to the following resources:

https://github.com/lucasresck/gnome-shell-extension-alt-tab-scroll-workaround
https://blogs.gnome.org/shell-dev/2023/09/02/extensions-in-gnome-45/
https://gjs.guide/extensions/upgrading/gnome-shell-45.html
https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/main.js#L833
https://gnome.pages.gitlab.gnome.org/mutter/meta/method.Window.activate.html